### PR TITLE
ESP32 update: show flash progress on a dedicated screen

### DIFF
--- a/.changelog/esp32-update-progress-screen.changed.md
+++ b/.changelog/esp32-update-progress-screen.changed.md
@@ -1,0 +1,1 @@
+**ESP32 update: progress now shown on a dedicated screen** — the flash progress bar and percentage previously drew on top of the ESP32-update menu, overlaying it. They now render on a cleared, dedicated screen with a title and a "do not power off" hint. The completion dialog (OK to return to the menu) is unchanged.

--- a/m1_csrc/m1_esp32_fw_update.c
+++ b/m1_csrc/m1_esp32_fw_update.c
@@ -24,6 +24,7 @@
 #include "app_common.h"
 #include "m1_storage.h"
 #include "m1_md5_hash.h"
+#include "m1_esp32_progress.h"
 #include "m1_fw_update_bl.h"
 #include "m1_power_ctl.h"
 #include "m1_display.h"
@@ -369,6 +370,63 @@ void setting_esp32_start_address(void)
   * @retval None
   */
 /******************************************************************************/
+/******************************************************************************/
+/**
+  * @brief  Draw a dedicated full-screen progress view for the ESP32 update.
+  *         Clears the screen (so the bar/percent no longer overlay the menu)
+  *         and draws a title + a "do not power off" hint.  fw_gui_progress_update()
+  *         then renders the bar/percent in the lower area on this clean screen.
+  */
+/******************************************************************************/
+static void esp32_update_draw_progress_bar(size_t remainder)
+{
+	static size_t total = 0;
+	static int last_percent = -1;
+	uint8_t percent;
+	char txt[16];
+	const int bx = 8, by = 48, bw = 112, bh = 12; /* progress bar geometry */
+
+	if (remainder == SIZE_MAX) { total = 0; last_percent = -1; return; } /* reset */
+	if (total < remainder) { total = remainder; last_percent = -1; }      /* init */
+	if (total == 0) return;
+
+	percent = esp32_update_progress_percent(total, remainder);
+	if ((int)percent == last_percent) return; /* redraw only when the %% changes */
+	last_percent = (int)percent;
+
+	/* clear the area below the header */
+	u8g2_SetDrawColor(&m1_u8g2, M1_DISP_DRAW_COLOR_BG);
+	u8g2_DrawBox(&m1_u8g2, 0, 34, M1_LCD_DISPLAY_WIDTH, M1_LCD_DISPLAY_HEIGHT - 34);
+	u8g2_SetDrawColor(&m1_u8g2, M1_DISP_DRAW_COLOR_TXT);
+
+	/* percentage centered above the bar */
+	u8g2_SetFont(&m1_u8g2, M1_DISP_SUB_MENU_FONT_N);
+	sprintf(txt, "%u%%", (unsigned)percent);
+	m1_draw_text(&m1_u8g2, 0, 42, M1_LCD_DISPLAY_WIDTH, txt, TEXT_ALIGN_CENTER);
+
+	/* bar frame + fill */
+	u8g2_DrawFrame(&m1_u8g2, bx, by, bw, bh);
+	{
+		int fillw = ((bw - 2) * (int)percent) / 100;
+		if (fillw > 0)
+			u8g2_DrawBox(&m1_u8g2, bx + 1, by + 1, fillw, bh - 2);
+	}
+	m1_u8g2_nextpage();
+}
+
+static void esp32_update_draw_progress_header(void)
+{
+	/* Clear the whole screen so nothing from the menu shows through. */
+	u8g2_SetDrawColor(&m1_u8g2, M1_DISP_DRAW_COLOR_BG);
+	u8g2_DrawBox(&m1_u8g2, 0, 0, M1_LCD_DISPLAY_WIDTH, M1_LCD_DISPLAY_HEIGHT);
+	u8g2_SetDrawColor(&m1_u8g2, M1_DISP_DRAW_COLOR_TXT);
+	u8g2_SetFont(&m1_u8g2, M1_DISP_SUB_MENU_FONT_N);
+	m1_draw_text(&m1_u8g2, 2, 9, 124, "ESP32 Update", TEXT_ALIGN_CENTER);
+	u8g2_DrawHLine(&m1_u8g2, 0, 12, M1_LCD_DISPLAY_WIDTH);
+	m1_draw_text(&m1_u8g2, 2, 28, 124, "Do not power off", TEXT_ALIGN_CENTER);
+	m1_u8g2_nextpage();
+}
+
 void setting_esp32_firmware_update(void)
 {
 	uint8_t uret, old_op_mode;
@@ -397,6 +455,11 @@ void setting_esp32_firmware_update(void)
         m1_device_stat.op_mode = M1_OPERATION_MODE_FIRMWARE_UPDATE;
 
         m1_led_fw_update_on(NULL); // Turn on
+
+        /* Dedicated full-screen progress view (no more menu overlay). */
+        esp32_update_draw_progress_header();
+        esp32_update_draw_progress_bar(SIZE_MAX); /* reset progress state for a clean redraw */
+
         m1_wdt_reset(); /* Kick IWDG before entering the flash operation */
 		esp32_UART_deinit(); // Disable the ESP32 module first
     	uret = m1_fw_app(&hfile_fw);
@@ -483,7 +546,7 @@ static esp_loader_error_t m1_fw_app(FIL *hfile)
 	};
 
 	write_size = image_size;
-	fw_gui_progress_update(write_size);
+	esp32_update_draw_progress_bar(write_size);
 
 	loader_port_stm32_init(&config);
 	esp32_UART_init();
@@ -518,7 +581,7 @@ static esp_loader_error_t m1_fw_app(FIL *hfile)
 			if ( flash_err != ESP_LOADER_SUCCESS )
 				break;
 			write_size -= count;
-			fw_gui_progress_update(write_size);
+			esp32_update_draw_progress_bar(write_size);
 		} // while ( write_size )
 
 		if ( write_size || (flash_err != ESP_LOADER_SUCCESS) )

--- a/m1_csrc/m1_esp32_fw_update.c
+++ b/m1_csrc/m1_esp32_fw_update.c
@@ -385,7 +385,6 @@ void setting_esp32_start_address(void)
   * @retval None
   */
 /******************************************************************************/
-/******************************************************************************/
 /**
   * @brief  Draw a dedicated full-screen progress view for the ESP32 update.
   *         Clears the screen (so the bar/percent no longer overlay the menu)

--- a/m1_csrc/m1_esp32_progress.h
+++ b/m1_csrc/m1_esp32_progress.h
@@ -1,0 +1,28 @@
+/* See COPYING.txt for license details. */
+
+#ifndef M1_ESP32_PROGRESS_H_
+#define M1_ESP32_PROGRESS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * esp32_update_progress_percent() - pure, host-testable progress calc for the
+ * ESP32 firmware-update bar.
+ *
+ *   total     = full image size in bytes
+ *   remainder = bytes still left to flash (full at start, 0 when done)
+ *
+ * Returns 0..100.  Guards total == 0 and clamps remainder > total so the bar
+ * can never report a bogus or out-of-range percentage.
+ */
+static inline uint8_t esp32_update_progress_percent(size_t total, size_t remainder)
+{
+    if (total == 0)
+        return 0;
+    if (remainder > total)
+        remainder = total;
+    return (uint8_t)(((uint64_t)(total - remainder) * 100u) / total);
+}
+
+#endif /* M1_ESP32_PROGRESS_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -913,6 +913,22 @@ endif()
 add_test(NAME rgb_backlight COMMAND test_rgb_backlight)
 
 # ------------------------------------------------------------------
+# Module under test: esp32 update progress percentage
+# Pure math for the firmware-update progress bar.
+# ------------------------------------------------------------------
+add_executable(test_esp32_progress
+    test_esp32_progress.c
+)
+target_include_directories(test_esp32_progress PRIVATE
+    ${M1_ROOT}/m1_csrc
+)
+target_link_libraries(test_esp32_progress PRIVATE unity)
+if(TARGET sanitizers)
+    target_link_libraries(test_esp32_progress PRIVATE sanitizers)
+endif()
+add_test(NAME esp32_progress COMMAND test_esp32_progress)
+
+# ------------------------------------------------------------------
 # Module under test: str_contains_icase (IR Universal Remote search helper)
 # Pure function — case-insensitive substring search used by IRDB search.
 # Uses a standalone copy because m1_ir_universal.c has HAL/RTOS dependencies.

--- a/tests/test_esp32_progress.c
+++ b/tests/test_esp32_progress.c
@@ -1,0 +1,26 @@
+#include "unity.h"
+#include "m1_esp32_progress.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_progress_start_is_zero(void)   { TEST_ASSERT_EQUAL_UINT8(0,   esp32_update_progress_percent(1000, 1000)); }
+void test_progress_done_is_100(void)     { TEST_ASSERT_EQUAL_UINT8(100, esp32_update_progress_percent(1000, 0)); }
+void test_progress_half(void)            { TEST_ASSERT_EQUAL_UINT8(50,  esp32_update_progress_percent(1000, 500)); }
+void test_progress_three_quarter(void)   { TEST_ASSERT_EQUAL_UINT8(75,  esp32_update_progress_percent(1000, 250)); }
+void test_progress_total_zero_guarded(void) { TEST_ASSERT_EQUAL_UINT8(0, esp32_update_progress_percent(0, 0)); }
+void test_progress_remainder_gt_total_clamped(void) { TEST_ASSERT_EQUAL_UINT8(0, esp32_update_progress_percent(1000, 2000)); }
+void test_progress_real_image_half(void) { TEST_ASSERT_EQUAL_UINT8(50, esp32_update_progress_percent(1404624, 702312)); }
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_progress_start_is_zero);
+    RUN_TEST(test_progress_done_is_100);
+    RUN_TEST(test_progress_half);
+    RUN_TEST(test_progress_three_quarter);
+    RUN_TEST(test_progress_total_zero_guarded);
+    RUN_TEST(test_progress_remainder_gt_total_clamped);
+    RUN_TEST(test_progress_real_image_half);
+    return UNITY_END();
+}


### PR DESCRIPTION
 ## Description

  During an ESP32 firmware update, the progress bar and percentage were drawn at
  fixed positions **on top of the ESP32-update menu**, overlaying it.

  This change draws a **dedicated full-screen progress view** when the flash
  starts:

          ESP32 Update
    ──────────────────────
       Do not power off
             45%
    [████████░░░░░░░░░░]

  - The screen is cleared and a title + "Do not power off" hint are shown.
  - A clean framed progress bar (outline + fill) renders with a centered
    percentage, on its own screen — no menu underneath.
  - The bar redraws **only when the integer percentage changes**, so the ~1,370
    flash chunks don't trigger a screen flush each and slow the update.
  - The completion dialog ("Update complete!" / "Update failed!", press OK to
    return to the menu) is unchanged.

  The progress-percentage math is extracted into a pure, host-testable helper
  `esp32_update_progress_percent()` (`m1_csrc/m1_esp32_progress.h`).

  Only the main update path (`m1_fw_app`) is affected; the separate
  `setting_esp32_backup_flash` path is left as-is.

  ## Type of Change
  - [x] New feature (non-breaking change which adds functionality)

  ## Hardware Requirements
  - M1 Device: Main Board REV2.8R

  ## Testing Environment
  - Toolchain: CMake + arm-none-eabi-gcc 14.2
  - Host tests: GCC + Unity (ctest)

  ## How Has This Been Tested?
  - [x] On-device, REV2.8R: ran an ESP32 firmware update from the SD card. The
        progress now renders on a clean dedicated screen (no menu overlay); the
        bar fills smoothly and the OK completion dialog appears at the end.
  - [x] Host unit tests for the percentage helper (`tests/test_esp32_progress.c`,
        7 cases: start=0, done=100, mid values, total=0 guard, remainder>total
        clamp, real image size). Full suite: 76/76 pass.

  ## Checklist:
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation (changelog fragment)
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective
  - [x] New and existing unit tests pass locally with my changes